### PR TITLE
New resource links

### DIFF
--- a/resources.html
+++ b/resources.html
@@ -26,13 +26,13 @@
         </p>
         <h2>Contents</h2>
         <ul>
-            <li><a href="#getting-started">Getting Started</a></li>
-            <li><a href="#compression">Compression</a></li>
-            <li><a href="#music">Music</a></li>
-            <li><a href="#texture">Texture</a></li>
-            <li><a href="#meshes">Meshes</a></li>
-            <li><a href="#ray-marching">Ray Marching</a></li>
-            <li><a href="#making-ofs">Making-ofs</a></li>
+            <li><a href="#getting-started">Getting Started</a>
+            <li><a href="#compression">Compression</a>
+            <li><a href="#music">Music</a>
+            <li><a href="#texture">Texture</a>
+            <li><a href="#meshes">Meshes</a>
+            <li><a href="#ray-marching">Ray Marching</a>
+            <li><a href="#making-ofs">Making-ofs</a>
         </ul>
     </div>
 
@@ -59,10 +59,10 @@
         </p>
         <ul>
             <li><a href="https://github.com/Kwarf/64k-starter">64k-starter</a> is a good starting point for writing a 64k intro in
-                Rust.</li>
+                Rust.
             <li><a href="https://madethisthing.com/iq/Demo-Framework-64k">Demo-Framework-64k</a> can be used a template for intros
-                in C++.</li>
-            <li><a href="https://conspiracy.hu/articles/11-creating-a-tiny-windows-executable/">Creating a tiny Windows executable</a> explains how to get Visual Studio to compile a minimal working executable.</li>
+                in C++.
+            <li><a href="https://conspiracy.hu/articles/11-creating-a-tiny-windows-executable/">Creating a tiny Windows executable</a> explains how to get Visual Studio to compile a minimal working executable.
         </ul>
     </div>
     
@@ -83,10 +83,10 @@
         <div class="links">
             <h5>At a glance</h5>
             <ul>
-                <li>Windows 32 bits</li>
-                <li><a href="http://www.farbrausch.de/~fg/kkrunchy/">kkrunchy project page</a> and <a href="https://github.com/farbrausch/fr_public/tree/master/kkrunchy">source code</a></li>
-                <li><a href="https://github.com/ConspiracyHu/rekkrunchy-with-analytics">rekkrunchy project page and source code</a></li>
-                <li><a href="https://fgiesen.wordpress.com/2011/01/24/x86-code-compression-in-kkrunchy/">Article: x86 code compression in kkrunchy</a></li>
+                <li>Windows 32 bits
+                <li><a href="http://www.farbrausch.de/~fg/kkrunchy/">kkrunchy project page</a> and <a href="https://github.com/farbrausch/fr_public/tree/master/kkrunchy">source code</a>
+                <li><a href="https://github.com/ConspiracyHu/rekkrunchy-with-analytics">rekkrunchy project page and source code</a>
+                <li><a href="https://fgiesen.wordpress.com/2011/01/24/x86-code-compression-in-kkrunchy/">Article: x86 code compression in kkrunchy</a>
             </ul>
         </div>
 
@@ -98,12 +98,12 @@
         <div class="links">
             <h5>At a glance</h5>
             <ul>
-                <li>Windows 32 bits and 64 bits</li>
-                <li>Currently the best compression</li>
-                <li><a href="https://logicoma.io/squishy/">squishy project page</a></li>
-                <li><a href="https://docs.google.com/spreadsheets/d/1tbQ7fgnG5DAI06eFoXvkE8fZKnrO4SpYQrrBbsmwdWk/edit?usp=sharing">squishy / kkrunchy comparison</a></li>
-                <li><a href="https://www.youtube.com/watch?v=O5LfE_qNzes">Revision 2020 seminar: modern 64k intro compression</a></li>
-                <li><a href="https://yupferris.github.io/blog/2020/08/31/c64-4k-intro-packer-deep-dive.html#squishys-decompressor-compressor">Blog post with some details about squishy</a></li>
+                <li>Windows 32 bits and 64 bits
+                <li>Currently the best compression
+                <li><a href="https://logicoma.io/squishy/">squishy project page</a>
+                <li><a href="https://docs.google.com/spreadsheets/d/1tbQ7fgnG5DAI06eFoXvkE8fZKnrO4SpYQrrBbsmwdWk/edit?usp=sharing">squishy / kkrunchy comparison</a>
+                <li><a href="https://www.youtube.com/watch?v=O5LfE_qNzes">Revision 2020 seminar: modern 64k intro compression</a>
+                <li><a href="https://yupferris.github.io/blog/2020/08/31/c64-4k-intro-packer-deep-dive.html#squishys-decompressor-compressor">Blog post with some details about squishy</a>
             </ul>
         </div>
 
@@ -115,8 +115,8 @@
         <div class="links">
             <h5>At a glance</h5>
             <ul>
-                <li>For 1k, 4k, 8k, but not for 64k</li>
-                <li><a href="https://github.com/runestubbe/Crinkler">Crinkler project page and source code</a></li>
+                <li>For 1k, 4k, 8k, but not for 64k
+                <li><a href="https://github.com/runestubbe/Crinkler">Crinkler project page and source code</a>
             </ul>
         </div>
 
@@ -124,8 +124,8 @@
 
         <p>The two most common tools for packing Javascript are:</p>
         <ul>
-            <li><a href="https://www.pouet.net/prod.php?which=59298">JsExe</a></li>
-            <li><a href="https://gist.github.com/gasman/2560551">pnginator.rb</a></li>
+            <li><a href="https://www.pouet.net/prod.php?which=59298">JsExe</a>
+            <li><a href="https://gist.github.com/gasman/2560551">pnginator.rb</a>
         </ul>
 
         <h3>Shader minification</h3>
@@ -138,9 +138,9 @@
         <div class="links">
             <h5>At a glance</h5>
             <ul>
-                <li>GLSL and HLSL</li>
-                <li><a href="https://github.com/laurentlb/Shader_Minifier">Shader Minifier project page and source code</a></li>
-                <li><a href="https://www.youtube.com/watch?v=S-VDVgCBy-M">Revision 2023 seminar: Shader minification for 4k - 64k intros</a></li>
+                <li>GLSL and HLSL
+                <li><a href="https://github.com/laurentlb/Shader_Minifier">Shader Minifier project page and source code</a>
+                <li><a href="https://www.youtube.com/watch?v=S-VDVgCBy-M">Revision 2023 seminar: Shader minification for 4k - 64k intros</a>
             </ul>
         </div>
 
@@ -153,11 +153,11 @@
         </p>
         <p>Some techniques can be useful:</p>
         <ul>
-            <li>Group data by type, so that similar things are packed together.</li>
+            <li>Group data by type, so that similar things are packed together.
             <li>Repetitive data doesn't take much space. Sometimes, the smart "Don't Repeat Youself" principle can be
-                counterproductive.</li>
-            <li>Try <a href="https://en.wikipedia.org/wiki/Delta_encoding">delta encoding</a>.</li>
-            <li><a href="https://www.ctrl-alt-test.fr/2018/making-floating-point-numbers-smaller/">Make the floats smaller</a>.</li>
+                counterproductive.
+            <li>Try <a href="https://en.wikipedia.org/wiki/Delta_encoding">delta encoding</a>.
+            <li><a href="https://www.ctrl-alt-test.fr/2018/making-floating-point-numbers-smaller/">Make the floats smaller</a>.
         </ul>
         <p>
             You may also read <a href="https://conspiracy.hu/articles/6/">Why are SMF files smaller?</a> about packing the music
@@ -175,11 +175,11 @@
         </p>
         <ul>
             <li><a href="https://github.com/hzdgopher/64klang">64klang</a>, an extended version of 4klang (a popular synth for 4k
-                intros).</li>
-            <li><a href="https://github.com/logicomacorp/WaveSabre">WaveSabre</a>, used in Logicoma intros and many others.</li>
-            <li><a href="https://tunefish-synth.com/">Tunefish</a>, used in Brain Control intros.</li>
+                intros).
+            <li><a href="https://github.com/logicomacorp/WaveSabre">WaveSabre</a>, used in Logicoma intros and many others.
+            <li><a href="https://tunefish-synth.com/">Tunefish</a>, used in Brain Control intros.
             <li><a href="http://1337haxorz.de/products.html">v2</a> was a popular option around 2005-2015. It uses less
-                CPU than the alternatives above, but it can feel slightly outdated.</li>
+                CPU than the alternatives above, but it can feel slightly outdated.
         </ul>
     </div>
 
@@ -195,22 +195,22 @@
         <p>General introduction to texture generation:</p>
         <ul>
             <li><a href="http://www.upvector.com/?section=Tutorials&subsection=Intro%20to%20Procedural%20Textures">Intro to
-                    Procedural Textures</a></li>
+                    Procedural Textures</a>
             <li><a href="https://www.ctrl-alt-test.fr/2018/texturing-in-a-64kb-intro/">Texturing in a 64kB intro</a>, an overview of
-                the texture generation in H – Immersion.</li>
+                the texture generation in H – Immersion.
         </ul>
 
         <h3>Voronoi</h3>
         <p>Voronoi diagrams are a simple tool for procedural generation and can be used in a variety of ways:</p>
         <ul>
-            <li><a href="https://thebookofshaders.com/12/">Cellular Noise</a>, a good overview of the Voronoi algorithm, from the Book of Shaders.</li>
-            <li><a href="https://www.alanzucconi.com/2015/02/24/to-voronoi-and-beyond/">To Voronoi and Beyond</a>, another introduction that also discusses other applications.</li>
+            <li><a href="https://thebookofshaders.com/12/">Cellular Noise</a>, a good overview of the Voronoi algorithm, from the Book of Shaders.
+            <li><a href="https://www.alanzucconi.com/2015/02/24/to-voronoi-and-beyond/">To Voronoi and Beyond</a>, another introduction that also discusses other applications.
             <li>Inigo Quilez wrote multiple articles: <a href="https://iquilezles.org/articles/cellularffx/">voronoi effect</a>,
                 <a href="https://iquilezles.org/articles/smoothvoronoi/">smooth voronoi</a>,
                 <a href="https://iquilezles.org/articles/voronoilines/">voronoi edges</a>, and
-                <a href="https://iquilezles.org/articles/voronoise/">voronoise</a>.</li>
+                <a href="https://iquilezles.org/articles/voronoise/">voronoise</a>.
             <li><a href="https://fgiesen.wordpress.com/2010/03/28/how-to-generate-cellular-textures/">How to generate cellular
-                    textures</a> discusses the implementation and optimizations.</li>
+                    textures</a> discusses the implementation and optimizations.
         </ul>
     </div>
 
@@ -219,23 +219,23 @@
 
         <p>Some techniques that can be useful for including meshes in a 64k intro:</p>
         <ul>
-            <li><a href="https://iquilezles.org/articles/meshcompression/">Mesh compression</a></li>
+            <li><a href="https://iquilezles.org/articles/meshcompression/">Mesh compression</a>
             <li>The <a href="https://en.wikipedia.org/wiki/Catmull%E2%80%93Clark_subdivision_surface">catmull clark subdivision algorithm</a>
                 is useful to generate smooth surfaces from a low-poly mesh
-                (see <a href="https://iquilezles.org/articles/breakpoint2007/bp2007.pdf">this presentation</a> for a code sample).</li>
+                (see <a href="https://iquilezles.org/articles/breakpoint2007/bp2007.pdf">this presentation</a> for a code sample).
             <li><a href="https://en.wikipedia.org/wiki/Marching_cubes">Marching cubes</a> can be used to convert a signed distance
-                function into a traditional mesh.</li>
-            <li><a href=https://en.wikipedia.org/wiki/L-system">L-Systems</a> are a simple way to generate recursive objects, such as trees.</li>
+                function into a traditional mesh.
+            <li><a href=https://en.wikipedia.org/wiki/L-system">L-Systems</a> are a simple way to generate recursive objects, such as trees.
         </ul>
         <p>You may also check:</p>
         <ul>
             <li><a href="https://qoob.weebly.com/features.html">Qoob</a> a tiny modeling tool that can be used as
-                an inspiration.</li>
+                an inspiration.
             <li><a href="https://fgiesen.wordpress.com/2012/02/13/debris-opening-the-box/">The series of articles about Debris</a>
-                also contains information about mesh generation.</li>
+                also contains information about mesh generation.
             <li>The article <a href="https://www.ctrl-alt-test.fr/2023/procedural-3d-mesh-generation-in-a-64kb-intro/">Procedural 3D
-                mesh generation in a 64kB intro</a>.</li>
-            <li><a href="https://github.com/ConspiracyHu/apEx-public/blob/main/apEx/Phoenix/Mesh.cpp">The mesh generation source code in apEx</a>, the demomaking tool used by Conspiracy intros.</li>
+                mesh generation in a 64kB intro</a>.
+            <li><a href="https://github.com/ConspiracyHu/apEx-public/blob/main/apEx/Phoenix/Mesh.cpp">The mesh generation source code in apEx</a>, the demomaking tool used by Conspiracy intros.
         </ul>
     </div>
 
@@ -249,26 +249,26 @@
 
         <ul>
             <li><a href="https://jamie-wong.com/2016/07/15/ray-marching-signed-distance-functions/">
-                Ray Marching and Signed Distance Functions</a> is a good introduction.</li>
+                Ray Marching and Signed Distance Functions</a> is a good introduction.
             <li>Many <a href="https://iquilezles.org/articles/">articles from Inigo Quilez</a> discuss raymarching</a>.
                 <ul>
-                    <li>In particular, see the <a href="https://iquilezles.org/articles/distfunctions/">distance functions page</a>.</li>
+                    <li>In particular, see the <a href="https://iquilezles.org/articles/distfunctions/">distance functions page</a>.
                 </ul>
             </li>
-            <li>The <a href="https://mercury.sexy/hg_sdf/">Mercury SDF toolbox</a> provides another set of common SDF.</li>
+            <li>The <a href="https://mercury.sexy/hg_sdf/">Mercury SDF toolbox</a> provides another set of common SDF.
         </ul>
     </div>
 
     <div class="card">
         <h2 id="making-ofs">Making-ofs</h2>
         <ul>
-            <li><a href="https://www.youtube.com/watch?v=Y3d8jR_IwYw">Atlas 64k Graphics Breakdown - Demoscene Stream</a>, 2019</li>
-            <li><a href="https://www.ctrl-alt-test.fr/2018/a-dive-into-the-making-of-immersion/">A dive into the making of Immersion</a>, 2018</li>
-            <li><a href="http://www.lofibucket.com/articles/64k_intro.html">How a 64k intro is made</a>, 2017</li>
-            <li><a href="https://geidav.wordpress.com/2013/04/14/making-of-turtles-all-the-way-down/">Making-of “Turtles all the way down”</a>, 2013</li>
-            <li><a href="http://peisik.untergrund.net/zine/gaia_machina/">Making of Gaia Machina</a>, 2012</li>
-            <li><a href="https://www.ctrl-alt-test.fr/2010/behind-incubation/">Behind Incubation</a>, 2010</li>
-            <li><a href="https://iquilezles.org/articles/breakpoint2007/bp2007.pdf">Tricks and techniques for rgba's past and future intros</a>, 2007</li>
+            <li><a href="https://www.youtube.com/watch?v=Y3d8jR_IwYw">Atlas 64k Graphics Breakdown - Demoscene Stream</a>, 2019
+            <li><a href="https://www.ctrl-alt-test.fr/2018/a-dive-into-the-making-of-immersion/">A dive into the making of Immersion</a>, 2018
+            <li><a href="http://www.lofibucket.com/articles/64k_intro.html">How a 64k intro is made</a>, 2017
+            <li><a href="https://geidav.wordpress.com/2013/04/14/making-of-turtles-all-the-way-down/">Making-of “Turtles all the way down”</a>, 2013
+            <li><a href="http://peisik.untergrund.net/zine/gaia_machina/">Making of Gaia Machina</a>, 2012
+            <li><a href="https://www.ctrl-alt-test.fr/2010/behind-incubation/">Behind Incubation</a>, 2010
+            <li><a href="https://iquilezles.org/articles/breakpoint2007/bp2007.pdf">Tricks and techniques for rgba's past and future intros</a>, 2007
         </ul>
 
         <p>

--- a/resources.html
+++ b/resources.html
@@ -235,6 +235,7 @@
                 also contains information about mesh generation.</li>
             <li>The article <a href="https://www.ctrl-alt-test.fr/2023/procedural-3d-mesh-generation-in-a-64kb-intro/">Procedural 3D
                 mesh generation in a 64kB intro</a>.</li>
+            <li><a href="https://github.com/ConspiracyHu/apEx-public/blob/main/apEx/Phoenix/Mesh.cpp">The mesh generation source code in apEx</a>, the demomaking tool used by Conspiracy intros.</li>
         </ul>
     </div>
 
@@ -274,6 +275,9 @@
             Not stricly a making of, <a href="https://fgiesen.wordpress.com/2012/02/13/debris-opening-the-box/">Debris: Opening the
                 box</a> is a great series of highly technical articles from 2010 to 2012, about the design decisions behind the
             engine and the tools written for the mid 2000s Farbrausch intros.
+        </p>
+        <p>
+            Moreover, Conspiracy has released the <a href="https://github.com/ConspiracyHu/apEx-public">source code of apEx</a>, the demomaking tool they used for their intros between 2014 and 2023, as well as the projects for those intros.
         </p>
     </div>
 

--- a/resources.html
+++ b/resources.html
@@ -62,6 +62,7 @@
                 Rust.</li>
             <li><a href="https://madethisthing.com/iq/Demo-Framework-64k">Demo-Framework-64k</a> can be used a template for intros
                 in C++.</li>
+            <li><a href="https://conspiracy.hu/articles/11-creating-a-tiny-windows-executable/">Creating a tiny Windows executable</a> explains how to get Visual Studio to compile a minimal working executable.</li>
         </ul>
     </div>
     

--- a/resources.html
+++ b/resources.html
@@ -59,9 +59,9 @@
         </p>
         <ul>
             <li><a href="https://github.com/Kwarf/64k-starter">64k-starter</a> is a good starting point for writing a 64k intro in
-                Rust.
+                Rust.</li>
             <li><a href="https://madethisthing.com/iq/Demo-Framework-64k">Demo-Framework-64k</a> can be used a template for intros
-                in C++.
+                in C++.</li>
         </ul>
     </div>
     
@@ -82,10 +82,10 @@
         <div class="links">
             <h5>At a glance</h5>
             <ul>
-                <li>Windows 32 bits
-                <li><a href="http://www.farbrausch.de/~fg/kkrunchy/">kkrunchy project page</a> and <a href="https://github.com/farbrausch/fr_public/tree/master/kkrunchy">source code</a><
-                <li><a href="https://github.com/ConspiracyHu/rekkrunchy-with-analytics">rekkrunchy project page and source code</a>
-                <li><a href="https://fgiesen.wordpress.com/2011/01/24/x86-code-compression-in-kkrunchy/">Article: x86 code compression in kkrunchy</a>
+                <li>Windows 32 bits</li>
+                <li><a href="http://www.farbrausch.de/~fg/kkrunchy/">kkrunchy project page</a> and <a href="https://github.com/farbrausch/fr_public/tree/master/kkrunchy">source code</a></li>
+                <li><a href="https://github.com/ConspiracyHu/rekkrunchy-with-analytics">rekkrunchy project page and source code</a></li>
+                <li><a href="https://fgiesen.wordpress.com/2011/01/24/x86-code-compression-in-kkrunchy/">Article: x86 code compression in kkrunchy</a></li>
             </ul>
         </div>
 
@@ -97,12 +97,12 @@
         <div class="links">
             <h5>At a glance</h5>
             <ul>
-                <li>Windows 32 bits and 64 bits
-                <li>Currently the best compression
-                <li><a href="https://logicoma.io/squishy/">squishy project page</a>
-                <li><a href="https://docs.google.com/spreadsheets/d/1tbQ7fgnG5DAI06eFoXvkE8fZKnrO4SpYQrrBbsmwdWk/edit?usp=sharing">squishy / kkrunchy comparison</a>
-                <li><a href="https://www.youtube.com/watch?v=O5LfE_qNzes">Revision 2020 seminar: modern 64k intro compression</a>
-                <li><a href="https://yupferris.github.io/blog/2020/08/31/c64-4k-intro-packer-deep-dive.html#squishys-decompressor-compressor">Blog post with some details about squishy</a>
+                <li>Windows 32 bits and 64 bits</li>
+                <li>Currently the best compression</li>
+                <li><a href="https://logicoma.io/squishy/">squishy project page</a></li>
+                <li><a href="https://docs.google.com/spreadsheets/d/1tbQ7fgnG5DAI06eFoXvkE8fZKnrO4SpYQrrBbsmwdWk/edit?usp=sharing">squishy / kkrunchy comparison</a></li>
+                <li><a href="https://www.youtube.com/watch?v=O5LfE_qNzes">Revision 2020 seminar: modern 64k intro compression</a></li>
+                <li><a href="https://yupferris.github.io/blog/2020/08/31/c64-4k-intro-packer-deep-dive.html#squishys-decompressor-compressor">Blog post with some details about squishy</a></li>
             </ul>
         </div>
 
@@ -114,8 +114,8 @@
         <div class="links">
             <h5>At a glance</h5>
             <ul>
-                <li>For 1k, 4k, 8k, but not for 64k
-                <li><a href="https://github.com/runestubbe/Crinkler">Crinkler project page and source code</a>
+                <li>For 1k, 4k, 8k, but not for 64k</li>
+                <li><a href="https://github.com/runestubbe/Crinkler">Crinkler project page and source code</a></li>
             </ul>
         </div>
 
@@ -123,8 +123,8 @@
 
         <p>The two most common tools for packing Javascript are:</p>
         <ul>
-            <li><a href="https://www.pouet.net/prod.php?which=59298">JsExe</a>
-            <li><a href="https://gist.github.com/gasman/2560551">pnginator.rb</a>
+            <li><a href="https://www.pouet.net/prod.php?which=59298">JsExe</a></li>
+            <li><a href="https://gist.github.com/gasman/2560551">pnginator.rb</a></li>
         </ul>
 
         <h3>Shader minification</h3>
@@ -137,9 +137,9 @@
         <div class="links">
             <h5>At a glance</h5>
             <ul>
-                <li>GLSL and HLSL
-                <li><a href="https://github.com/laurentlb/Shader_Minifier">Shader Minifier project page and source code</a>
-                <li><a href="https://www.youtube.com/watch?v=S-VDVgCBy-M">Revision 2023 seminar: Shader minification for 4k - 64k intros</a>
+                <li>GLSL and HLSL</li>
+                <li><a href="https://github.com/laurentlb/Shader_Minifier">Shader Minifier project page and source code</a></li>
+                <li><a href="https://www.youtube.com/watch?v=S-VDVgCBy-M">Revision 2023 seminar: Shader minification for 4k - 64k intros</a></li>
             </ul>
         </div>
 
@@ -152,11 +152,11 @@
         </p>
         <p>Some techniques can be useful:</p>
         <ul>
-            <li>Group data by type, so that similar things are packed together.
+            <li>Group data by type, so that similar things are packed together.</li>
             <li>Repetitive data doesn't take much space. Sometimes, the smart "Don't Repeat Youself" principle can be
-                counterproductive.
-            <li>Try <a href="https://en.wikipedia.org/wiki/Delta_encoding">delta encoding</a>.
-            <li><a href="https://www.ctrl-alt-test.fr/2018/making-floating-point-numbers-smaller/">Make the floats smaller</a>.
+                counterproductive.</li>
+            <li>Try <a href="https://en.wikipedia.org/wiki/Delta_encoding">delta encoding</a>.</li>
+            <li><a href="https://www.ctrl-alt-test.fr/2018/making-floating-point-numbers-smaller/">Make the floats smaller</a>.</li>
         </ul>
         <p>
             You may also read <a href="https://conspiracy.hu/articles/6/">Why are SMF files smaller?</a> about packing the music
@@ -174,11 +174,11 @@
         </p>
         <ul>
             <li><a href="https://github.com/hzdgopher/64klang">64klang</a>, an extended version of 4klang (a popular synth for 4k
-                intros).
-            <li><a href="https://github.com/logicomacorp/WaveSabre">WaveSabre</a>, used in Logicoma intros and many others.
-            <li><a href="https://tunefish-synth.com/">Tunefish</a>, used in Brain Control intros.
+                intros).</li>
+            <li><a href="https://github.com/logicomacorp/WaveSabre">WaveSabre</a>, used in Logicoma intros and many others.</li>
+            <li><a href="https://tunefish-synth.com/">Tunefish</a>, used in Brain Control intros.</li>
             <li><a href="http://1337haxorz.de/products.html">v2</a> was a popular option around 2005-2015. It uses less
-                CPU than the alternatives above, but it can feel slightly outdated.
+                CPU than the alternatives above, but it can feel slightly outdated.</li>
         </ul>
     </div>
 
@@ -194,22 +194,22 @@
         <p>General introduction to texture generation:</p>
         <ul>
             <li><a href="http://www.upvector.com/?section=Tutorials&subsection=Intro%20to%20Procedural%20Textures">Intro to
-                    Procedural Textures</a>
+                    Procedural Textures</a></li>
             <li><a href="https://www.ctrl-alt-test.fr/2018/texturing-in-a-64kb-intro/">Texturing in a 64kB intro</a>, an overview of
-                the texture generation in H – Immersion.
+                the texture generation in H – Immersion.</li>
         </ul>
 
         <h3>Voronoi</h3>
         <p>Voronoi diagrams are a simple tool for procedural generation and can be used in a variety of ways:</p>
         <ul>
-            <li><a href="https://thebookofshaders.com/12/">Cellular Noise</a>, a good overview of the Voronoi algorithm, from the Book of Shaders.
-            <li><a href="https://www.alanzucconi.com/2015/02/24/to-voronoi-and-beyond/">To Voronoi and Beyond</a>, another introduction that also discusses other applications.
+            <li><a href="https://thebookofshaders.com/12/">Cellular Noise</a>, a good overview of the Voronoi algorithm, from the Book of Shaders.</li>
+            <li><a href="https://www.alanzucconi.com/2015/02/24/to-voronoi-and-beyond/">To Voronoi and Beyond</a>, another introduction that also discusses other applications.</li>
             <li>Inigo Quilez wrote multiple articles: <a href="https://iquilezles.org/articles/cellularffx/">voronoi effect</a>,
                 <a href="https://iquilezles.org/articles/smoothvoronoi/">smooth voronoi</a>,
                 <a href="https://iquilezles.org/articles/voronoilines/">voronoi edges</a>, and
-                <a href="https://iquilezles.org/articles/voronoise/">voronoise</a>.
+                <a href="https://iquilezles.org/articles/voronoise/">voronoise</a>.</li>
             <li><a href="https://fgiesen.wordpress.com/2010/03/28/how-to-generate-cellular-textures/">How to generate cellular
-                    textures</a> discusses the implementation and optimizations.
+                    textures</a> discusses the implementation and optimizations.</li>
         </ul>
     </div>
 
@@ -218,24 +218,23 @@
 
         <p>Some techniques that can be useful for including meshes in a 64k intro:</p>
         <ul>
-            <li><a href="https://iquilezles.org/articles/meshcompression/">Mesh compression</a>
+            <li><a href="https://iquilezles.org/articles/meshcompression/">Mesh compression</a></li>
             <li>The <a href="https://en.wikipedia.org/wiki/Catmull%E2%80%93Clark_subdivision_surface">catmull clark subdivision algorithm</a>
                 is useful to generate smooth surfaces from a low-poly mesh
-                (see <a href="https://iquilezles.org/articles/breakpoint2007/bp2007.pdf">this presentation</a> for a code sample).
+                (see <a href="https://iquilezles.org/articles/breakpoint2007/bp2007.pdf">this presentation</a> for a code sample).</li>
             <li><a href="https://en.wikipedia.org/wiki/Marching_cubes">Marching cubes</a> can be used to convert a signed distance
-                function into a traditional mesh.
-            <li><a href=https://en.wikipedia.org/wiki/L-system">L-Systems</a> are a simple way to generate recursive objects, such as trees.
+                function into a traditional mesh.</li>
+            <li><a href=https://en.wikipedia.org/wiki/L-system">L-Systems</a> are a simple way to generate recursive objects, such as trees.</li>
         </ul>
         <p>You may also check:</p>
         <ul>
             <li><a href="https://qoob.weebly.com/features.html">Qoob</a> a tiny modeling tool that can be used as
-                an inspiration.
+                an inspiration.</li>
             <li><a href="https://fgiesen.wordpress.com/2012/02/13/debris-opening-the-box/">The series of articles about Debris</a>
-                also contains information about mesh generation.
+                also contains information about mesh generation.</li>
             <li>The article <a href="https://www.ctrl-alt-test.fr/2023/procedural-3d-mesh-generation-in-a-64kb-intro/">Procedural 3D
-                mesh generation in a 64kB intro</a>
+                mesh generation in a 64kB intro</a>.</li>
         </ul>
-    </p>
     </div>
 
     <div class="card">
@@ -248,25 +247,26 @@
 
         <ul>
             <li><a href="https://jamie-wong.com/2016/07/15/ray-marching-signed-distance-functions/">
-                Ray Marching and Signed Distance Functions</a> is a good introduction.
+                Ray Marching and Signed Distance Functions</a> is a good introduction.</li>
             <li>Many <a href="https://iquilezles.org/articles/">articles from Inigo Quilez</a> discuss raymarching</a>.
                 <ul>
-                    <li>In particular, see the <a href="https://iquilezles.org/articles/distfunctions/">distance functions page</a>.
+                    <li>In particular, see the <a href="https://iquilezles.org/articles/distfunctions/">distance functions page</a>.</li>
                 </ul>
-            <li>The <a href="https://mercury.sexy/hg_sdf/">Mercury SDF toolbox</a> provides another set of common SDF.
+            </li>
+            <li>The <a href="https://mercury.sexy/hg_sdf/">Mercury SDF toolbox</a> provides another set of common SDF.</li>
         </ul>
     </div>
 
     <div class="card">
         <h2 id="making-ofs">Making-ofs</h2>
         <ul>
-            <li><a href="https://www.youtube.com/watch?v=Y3d8jR_IwYw">Atlas 64k Graphics Breakdown - Demoscene Stream</a>, 2019
-            <li><a href="https://www.ctrl-alt-test.fr/2018/a-dive-into-the-making-of-immersion/">A dive into the making of Immersion</a>, 2018
-            <li><a href="http://www.lofibucket.com/articles/64k_intro.html">How a 64k intro is made</a>, 2017
-            <li><a href="https://geidav.wordpress.com/2013/04/14/making-of-turtles-all-the-way-down/">Making-of “Turtles all the way down”</a>, 2013
-            <li><a href="http://peisik.untergrund.net/zine/gaia_machina/">Making of Gaia Machina</a>, 2012
-            <li><a href="https://www.ctrl-alt-test.fr/2010/behind-incubation/">Behind Incubation</a>, 2010
-            <li><a href="https://iquilezles.org/articles/breakpoint2007/bp2007.pdf">Tricks and techniques for rgba's past and future intros</a>, 2007
+            <li><a href="https://www.youtube.com/watch?v=Y3d8jR_IwYw">Atlas 64k Graphics Breakdown - Demoscene Stream</a>, 2019</li>
+            <li><a href="https://www.ctrl-alt-test.fr/2018/a-dive-into-the-making-of-immersion/">A dive into the making of Immersion</a>, 2018</li>
+            <li><a href="http://www.lofibucket.com/articles/64k_intro.html">How a 64k intro is made</a>, 2017</li>
+            <li><a href="https://geidav.wordpress.com/2013/04/14/making-of-turtles-all-the-way-down/">Making-of “Turtles all the way down”</a>, 2013</li>
+            <li><a href="http://peisik.untergrund.net/zine/gaia_machina/">Making of Gaia Machina</a>, 2012</li>
+            <li><a href="https://www.ctrl-alt-test.fr/2010/behind-incubation/">Behind Incubation</a>, 2010</li>
+            <li><a href="https://iquilezles.org/articles/breakpoint2007/bp2007.pdf">Tricks and techniques for rgba's past and future intros</a>, 2007</li>
         </ul>
 
         <p>


### PR DESCRIPTION
This PR adds two resource links: an article on how to compile a minimal Windows binary, and the repository of the Conspiracy demotool. It fixes a few details.